### PR TITLE
Community creation of the Code of Conduct: Moved to PR #6 with contribution guideline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,99 @@
+As a community we welcome everyone, and encourage a friendly and positive environment.
+
+This code of conduct outlines our expectations for participants within the
+community, as well as steps to reporting unacceptable behavior. We are committed
+to providing a welcoming and inspiring community for all and expect our code of
+conduct to be honored. Anyone who violates this code of conduct may be banned
+from the community.
+
+Our open source community strives to:
+
+- **Be friendly and patient.**
+
+- **Be welcoming**: We strive to be a community that welcomes and supports
+  people of all backgrounds and identities. This includes, but is not limited to
+  members of any race, ethnicity, culture, national origin, colour, immigration
+  status, social and economic class, educational level, sex, sexual orientation,
+  gender identity and expression, age, size, family status, political belief,
+  religion, and mental and physical ability.
+
+- **Be considerate**: Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect users and
+  colleagues, and you should take those consequences into account when making
+  decisions. Remember that we're a world-wide community, so you might not be
+  communicating in someone else's primary language.
+
+- **Be respectful**: Not all of us will agree all the time, but disagreement is
+  no excuse for poor behavior and poor manners. We might all experience some
+  frustration now and then, but we cannot allow that frustration to turn into a
+  personal attack. It’s important to remember that a community where people feel
+  uncomfortable or threatened is not a productive one.
+
+- **Be careful in the words that we choose**: We are a community of
+  professionals, and we conduct ourselves professionally. Be kind to others. Do
+  not insult or put down other participants. Harassment and other exclusionary
+  behavior aren't acceptable. This includes, but is not limited to: Violent
+  threats or language directed against another person, Discriminatory jokes and
+  language, Posting sexually explicit or violent material, Posting (or
+  threatening to post) other people’s personally identifying information
+  (“doxing”), Personal insults, especially those using racist or sexist terms,
+  Unwelcome sexual attention, Advocating for, or encouraging, any of the above
+  behavior, Repeated harassment of others. In general, if someone asks you to
+  stop, then stop.
+
+- **Try to understand why we disagree**: Disagreements, both social and
+  technical, happen all the time. It is important that we resolve disagreements
+  and differing views constructively. Remember that we’re different. Diversity
+  contributes to the strength of our community, which is composed of people from
+  a wide range of backgrounds. Different people have different perspectives on
+  issues. Being unable to understand why someone holds a viewpoint doesn’t mean
+  that they’re wrong. Don’t forget that it is human to err and blaming each
+  other doesn’t get us anywhere. Instead, focus on helping to resolve issues and
+  learning from mistakes.
+
+### Diversity Statement
+
+We encourage everyone to participate and are committed to building a community
+for all. Although we will fail at times, we seek to treat everyone both as
+fairly and equally as possible. Whenever a participant has made a mistake, we
+expect them to take responsibility for it. If someone has been harmed or
+offended, it is our responsibility to listen carefully and respectfully, and do
+our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age,
+gender, gender identity or expression, culture, ethnicity, language, national
+origin, political beliefs, profession, race, religion, sexual orientation,
+socioeconomic status, and technical ability. We will not tolerate discrimination
+based on any of the protected characteristics above, including participants with
+disabilities.
+
+### Reporting Issues
+
+If you experience or witness unacceptable behavior, or have any other concerns,
+please report it by contacting the organisers - <ADD EMAIL OF A DESIGNATED MEMBERS>.
+
+To report an issue involving one of the members, please email other members individually.
+
+All reports will be handled with discretion. In your report please include:
+
+- Your contact information.
+
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If there
+  are additional witnesses, please include them as well. Your account of what
+  occurred, and if you believe the incident is ongoing. If there is a publicly
+  available record (e.g. a mailing list archive or a public IRC logger), please
+  include a link.
+
+- Any additional information that may be helpful.
+
+After filing a report, a representative will contact you personally, review the
+incident, follow up with any additional questions, and make a decision as to how
+to respond. If the person who is harassing you is part of the response team,
+they will recuse themselves from handling your incident. If the complaint
+originates from a member of the response team, it will be handled by a different
+member of the response team. We will respect confidentiality requests for the
+purpose of protecting victims of abuse.
+
+### Attribution & Acknowledgements
+
+This code of conduct is based on the Open Code of Conduct from the TODOGroup.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -72,7 +72,8 @@ disabilities.
 ### Reporting Issues
 
 If you experience or witness unacceptable behavior, or have any other concerns,
-please report it by contacting the organisers - <ADD EMAIL OF A DESIGNATED MEMBERS>.
+please report it by contacting the organisers:
+- <ADD EMAIL OF A DESIGNATED MEMBERS>.
 
 To report an issue involving one of the members, please email other members individually.
 
@@ -98,4 +99,4 @@ purpose of protecting victims of abuse.
 
 ### Attribution & Acknowledgements
 
-This code of conduct is based on the Open Code of Conduct from the TODOGroup.
+This code of conduct is based on the Open Code of Conduct from the [TODO Group](https://github.com/todogroup/opencodeofconduct/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
+# Code of Condct for the Covid-19-BH20 Event
+
 As a community we welcome everyone, and encourage a friendly and positive environment.
 
 This code of conduct outlines our expectations for participants within the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -73,7 +73,7 @@ disabilities.
 
 If you experience or witness unacceptable behavior, or have any other concerns,
 please report it by contacting the organisers:
-- <ADD EMAIL OF A DESIGNATED MEMBERS>.
+Leyla Garcia (email: ljgarciaco@gmail.com), Pjotr Prins (email: pjotr.public708@thebird.nl) and Tazro Ohta (email: t.ohta@dbcls.rois.ac.jp).
 
 To report an issue involving one of the members, please email other members individually.
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,14 @@ We will organize goals and mini-publications for each group. Contributors will g
 # Code of conduct
 
 Anyone participating agrees to abide by the code of conduct as given
-by [FOSDEM 2020](https://fosdem.org/2020/practical/conduct/). Here,
-please bring any concerns to the immediate attention of our
+stated on our [Code of Conduct](./CODE_OF_CONDUCT.md). Please bring any concerns to the immediate attention of our
 coordinating team:
 
 # Coordinating team
 
-1. Pjotr Prins, USA (pjotr.public708@thebird.nl)
-2. [Tazro Ohta](https://github.com/inutano), Japan (t.ohta@dbcls.rois.acjp)
-3. Leyla Garcia, Germany
+1. Pjotr Prins, USA (pjotr.public708 at thebird.nl)
+2. [Tazro Ohta](https://github.com/inutano), Japan (t.ohta at dbcls.rois.ac.jp)
+3. Leyla Garcia, Germany (ljgarciaco at gmail.com)
 
 # Contribute
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We will organize goals and mini-publications for each group. Contributors will g
 # Code of conduct
 
 Anyone participating agrees to abide by the code of conduct as given
-stated on our [Code of Conduct](./CODE_OF_CONDUCT.md). Please bring any concerns to the immediate attention of our
+by [Code of Conduct](./CODE_OF_CONDUCT.md). Please bring any concerns to the immediate attention of our
 coordinating team:
 
 # Coordinating team


### PR DESCRIPTION
## Summary

* Opening a pull request with the explicit invite for members to respond to the code of conduct.
* While this pull request adds only a single minor change, please use this opportunity to respond to the entire Code of Conduct.
* Building on PR #3 and PR #4 by Malvika:

> ## Where can the project lead help
> * Please add a few members as designated CoC report taker and responders (just writing organisers won't cut it)
> * Use a dedicated email address for CoC reporting
> * Gather approval from the members as comments, or use emojis " 👍: for approval and 👎: disagree" on this PR
>   
> * CoC should not be a token, make people think about it intentionally
> * Do not close this PR without addressing these issue